### PR TITLE
Export cleanup from /index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-export { test, it, beforeEach, beforeAll } from "./lib/api.js"
+export { test, it, beforeEach, beforeAll, cleanup } from "./lib/api.js"

--- a/index.test.js
+++ b/index.test.js
@@ -45,4 +45,21 @@ describe('running tests', function() {
     const files = glob.sync('./test/tmp/someTest*')
     assert.equal(files.length, 1)
   })
+
+  it('exposes the whole API', function () {
+    const stdout = execSync('./bin/runner.js "./test/api/kitchenSinkTest.js"', {
+      encoding: 'utf-8',
+    })
+    const logs = [
+      'beforeAll',
+      'beforeEach',
+      'test',
+      'cleanup beforeEach',
+      'beforeEach',
+      'it',
+      'cleanup beforeEach',
+      'cleanup beforeAll'
+    ]
+    assert.match(stdout.trim(), new RegExp(logs.join('[\\n\\s\\S]+'), 'g'))
+  });
 })

--- a/test/api/kitchenSinkTest.js
+++ b/test/api/kitchenSinkTest.js
@@ -1,0 +1,25 @@
+import { test, it, beforeEach, beforeAll, cleanup } from '../../index.js'
+
+beforeAll(function () {
+  console.log('beforeAll')
+
+  cleanup(function () {
+    console.log('cleanup beforeAll')
+  });
+});
+
+beforeEach(function () {
+  console.log('beforeEach')
+
+  cleanup(function () {
+    console.log('cleanup beforeEach')
+  });
+});
+
+test('works', function () {
+  console.log('test')
+});
+
+it('also works', function () {
+  console.log('it');
+});

--- a/test/cli/one/otherTest.js
+++ b/test/cli/one/otherTest.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import {test} from '../../../lib/api.js'
+import {test} from '../../../index.js'
 
 test('also works', () => {
   assert.ok(true)

--- a/test/cli/someTest.js
+++ b/test/cli/someTest.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import assert from 'node:assert'
-import { it, beforeEach } from '../../lib/api.js'
+import { it, beforeEach } from '../../index.js'
 
 beforeEach(function() {
   fs.rmSync('./test/tmp', { recursive: true, force: true })

--- a/test/error/failTest.js
+++ b/test/error/failTest.js
@@ -1,5 +1,5 @@
 import { equal } from 'assert'
-import { test } from '../../lib/api.js'
+import { test } from '../../index.js'
 
 test('fails', () => {
   equal(1, 2)


### PR DESCRIPTION
The readme says you can do this:

```js
import { cleanup } from 'assert-raisins'
```

...but you can't.

This fixes that, with a "kitchen sink" test (may be overboard, but feels like might be a useful high-level sanity check?)

Also change the imports for the other "example tests" so they go through the public (package main) API.